### PR TITLE
Display Enhacements

### DIFF
--- a/demos/pde.json
+++ b/demos/pde.json
@@ -341,13 +341,19 @@
         },
 
         {
+            "at": 29.75,
+            "on": "routine/trails",
+            "do": "disable"
+        },
+
+        {
             "at": 30.0,
             "on": "display/rgbtext",
             "do": "enable"
         },
 
         {
-            "at": 30.0,
+            "at": 30.1,
             "on": "routine/loader",
             "do": "enable"
         },
@@ -365,7 +371,8 @@
             "on": "routine/loader",
             "do": "update",
             "aParameters": {
-                "iState" : 2
+                "iState": 2,
+                "sMessage": "Program: The PHP Demo Engine Part 2!"
             }
         },
 
@@ -394,6 +401,12 @@
             "aParameters": {
                 "iState" : 2
             }
+        },
+
+        {
+            "at": 40.0,
+            "on": "routine/trails",
+            "do": "enable"
         },
 
         {

--- a/demos/tape.json
+++ b/demos/tape.json
@@ -47,7 +47,8 @@
             "on": "routine/loader",
             "do": "update",
             "aParameters": {
-                "iState" : 2
+                "iState" : 2,
+                "sMessage": "Program: PDE"
             }
         },
 
@@ -79,7 +80,7 @@
         },
 
         {
-            "at": 10.0,
+            "at": 20.0,
             "do": "end"
         }
     ]

--- a/src/display/ASCIIOverRGB.php
+++ b/src/display/ASCIIOverRGB.php
@@ -35,4 +35,8 @@ class ASCIIOverRGB extends BaseAsyncASCIIWithRGB {
         DATA_FORMAT   = self::DATA_FORMAT_32,          // Data transfer size
         PIXEL_FORMAT  = self::FORMAT_ASCII_RGB
     ;
+
+    protected function getDefaultPixelValue() : int {
+        return $this->iBGColour;
+    }
 }

--- a/src/display/DoubleVerticalRGB.php
+++ b/src/display/DoubleVerticalRGB.php
@@ -80,7 +80,7 @@ class DoubleVerticalRGB extends Base implements IPixelled, IAsynchronous {
 
         // Initialise the subprocess now as it only needs access to the properties evaluated to now.
         $this->initAsyncProcess();
-        $this->initPixelBuffer($iWidth, $iHeight, self::FORMAT_RGB);
+        $this->initPixelBuffer($iWidth, $iHeight, self::FORMAT_RGB, 0);
         $this->reset();
     }
 

--- a/src/display/PlainASCII.php
+++ b/src/display/PlainASCII.php
@@ -72,7 +72,7 @@ class PlainASCII extends Base implements IASCIIArt {
     }
 
     public function __destruct() {
-        echo IANSIControl::ATTR_RESET . IANSIControl::CRSR_ON, "\n";
+        echo IANSIControl::ATTR_RESET . IANSIControl::CRSR_ON . "\n";
         $this->reportRedraw();
     }
 

--- a/src/display/RGBASCII.php
+++ b/src/display/RGBASCII.php
@@ -35,4 +35,8 @@ class RGBASCII extends BaseAsyncASCIIWithRGB {
         DATA_FORMAT   = self::DATA_FORMAT_32,          // Data transfer size
         PIXEL_FORMAT  = self::FORMAT_RGB_ASCII
     ;
+
+    protected function getDefaultPixelValue() : int {
+        return $this->iFGColour;
+    }
 }

--- a/src/display/RGBASCIIOverRGB.php
+++ b/src/display/RGBASCIIOverRGB.php
@@ -48,7 +48,14 @@ class RGBASCIIOverRGB extends BaseAsyncASCIIWithRGB {
     /**
      * @inheritDoc
      */
-    protected function preparePixels() {
+    protected function getDefaultPixelValue() : int {
+        return $this->iBGColour | $this->iFGColour << 24;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function preparePixels() : void {
         $j = 0;
         $oPixels    = $this->getPixels();
         $sRawBuffer = $this->getCharacterBuffer();
@@ -106,7 +113,7 @@ class RGBASCIIOverRGB extends BaseAsyncASCIIWithRGB {
                 case 3:
                     // Foreground RGB changes
                     $sRawBuffer .= sprintf(
-                        IANSIControl::ATTR_BG_RGB_TPL,
+                        IANSIControl::ATTR_FG_RGB_TPL,
                         $iForeRGB >> 16,
                         ($iForeRGB >> 8) & 0xFF,
                         ($iForeRGB & 0xFF)

--- a/src/display/common/Base.php
+++ b/src/display/common/Base.php
@@ -75,7 +75,7 @@ abstract class Base implements PDE\IDisplay {
     /**
      * @inheritDoc
      */
-    public function waitForFrame() : self {
+    public function waitForFrame() : PDE\IDisplay {
         return $this;
     }
 

--- a/src/display/common/BaseAsyncASCIIWithRGB.class.php
+++ b/src/display/common/BaseAsyncASCIIWithRGB.class.php
@@ -47,7 +47,12 @@ abstract class BaseAsyncASCIIWithRGB extends Base implements IPixelled, IASCIIAr
         'sMaskRGB'     => 'FFFFFF'
     ];
 
-    use TASCIIArt, TPixelled, TInstrumented, TAsynchronous;
+    use
+        TASCIIArt,
+        TPixelled,
+        TInstrumented,
+        TAsynchronous
+    ;
 
     protected array $aLineBreaks = [];
 
@@ -60,11 +65,13 @@ abstract class BaseAsyncASCIIWithRGB extends Base implements IPixelled, IASCIIAr
         $aLineBreaks   = range(0, $iWidth * $iHeight, $iWidth);
         unset($aLineBreaks[0]);
         $this->aLineBreaks = array_fill_keys($aLineBreaks, "\n");
+        $this->iBGColour   = 0;
+        $this->iFGColour   = 0xFFFFFF;
 
         $this->initFixedColours();
         $this->initAsyncProcess();
         $this->initASCIIBuffer($iWidth, $iHeight);
-        $this->initPixelBuffer($iWidth, $iHeight, static::PIXEL_FORMAT);
+        $this->initPixelBuffer($iWidth, $iHeight, static::PIXEL_FORMAT, $this->getDefaultPixelValue());
         $this->reset();
     }
 
@@ -137,6 +144,7 @@ abstract class BaseAsyncASCIIWithRGB extends Base implements IPixelled, IASCIIAr
         if ($iColour != $this->iFGColour) {
             $this->iFGColour = $iColour;
             $this->sendSetForegroundColour($iColour);
+            $this->setDefaultPixelValue($this->getDefaultPixelValue());
         }
         return $this;
     }
@@ -153,6 +161,7 @@ abstract class BaseAsyncASCIIWithRGB extends Base implements IPixelled, IASCIIAr
         if ($iColour != $this->iBGColour) {
             $this->iBGColour = $iColour;
             $this->sendSetBackgroundColour($iColour);
+            $this->setDefaultPixelValue($this->getDefaultPixelValue());
         }
         return $this;
     }
@@ -252,11 +261,13 @@ abstract class BaseAsyncASCIIWithRGB extends Base implements IPixelled, IASCIIAr
      * Prepare the pixel array before submission to the asynchronous process. This is split out
      * so that it can be overridden.
      */
-    protected function preparePixels() {
+    protected function preparePixels() : void {
         $j = 0;
         foreach ($this->oPixels as $i => $iRGB) {
             $j += (int)isset($this->aLineBreaks[$i]);
             $this->oPixels[$i] = ord($this->sRawBuffer[$j++]) << 24 | $iRGB;
         }
     }
+
+    protected abstract function getDefaultPixelValue() : int;
 }

--- a/src/display/common/IASCIIArt.php
+++ b/src/display/common/IASCIIArt.php
@@ -103,6 +103,32 @@ interface IASCIIArt {
     public function getCharacterWidth() : int;
 
     /**
+     * Render a string of text starting at a given x/y coordinate. An optional max X and Y can be passed
+     * to define a bounding box, otherwise the edges of the display are used. Text that exceeds the width will
+     * be clipped.
+     *
+     * @param  string $sText
+     * @param  int    $iX
+     * @param  int    $iY
+     * @param  int    $iMaxX - If < 1, the maximum X ordinate of the display is used
+     * @param  int    $iMaxY - If < 1, the maximum Y ordinate of the display is used
+     * @return self
+     */
+    public function writeTextBounded(string $sText, int $iX, int $iY, int $iMaxX = 0, $iMaxY = 0) : self;
+
+    /**
+     * Simple text render. Does not support new lines, all text after a new line is discarded. Negative coordinates
+     * and overflow are handled.
+     *
+     * @param  string $sText
+     * @param  int    $iX
+     * @param  int    $iY
+     * @param  int    $iMaxX - If < 1, the maximum X ordinate of the display is used
+     * @return self
+     */
+    public function writeTextSpan(string $sText, int $iX, int $iY, int $iMaxX = 0) : self;
+
+    /**
      * Get the raw display buffer, aka 1337 mode, lol. String is returned by refrence so that modifying it has the
      * desired effect.
      *

--- a/src/display/common/TASCIIArt.php
+++ b/src/display/common/TASCIIArt.php
@@ -161,4 +161,110 @@ trait TASCIIArt {
         }
         return $this;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function writeTextBounded(string $sText, int $iX, int $iY, int $iMaxX = 0, $iMaxY = 0) : self {
+        if (
+            empty($sText)         || // nothing to render
+            $iX >= $this->iWidth  || // completely off right
+            $iY >= $this->iHeight    // completely off bottom
+        ) {
+            return $this;
+        }
+
+        // Determine boundary
+        $iMaxX = ($iMaxX < 1) ?
+            $this->iWidth :
+            min($iMaxX, $this->iWidth);
+        $iMaxY = ($iMaxY < 1) ?
+            $this->iHeight :
+            min($iMaxY, $this->iHeight);
+
+        if ($iX > $iMaxX || $iY > $iMaxY) {
+            return $this;
+        }
+
+        $aStrings = explode("\n", $sText);
+
+        if (count($aStrings) + $iY < 0) {
+            return $this; // Completely off the top
+        }
+
+        // Deal with negative Y coordinate
+        if ($iY < 0) {
+            $aStrings    = array_slice($aStrings, -$iY);
+            $iY          = 0;
+        }
+
+        foreach ($aStrings as $sString) {
+            if ($iY > $iMaxY) {
+                break;
+            }
+            $this->writeRightClippedSpan($sString, $iX, $iY++, $iMaxX);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function writeTextSpan(string $sText, int $iX, int $iY, int $iMaxX = 0) : self {
+
+        $iMaxX = ($iMaxX < 1) ?
+            $this->iWidth :
+            min($iMaxX, $this->iWidth);
+
+        // Sanity check
+        if (
+            $iY <  0              ||
+            $iY >= $this->iHeight ||
+            $iX >  $iMaxX         ||
+            empty($sText)
+        ) {
+            return $this;
+        }
+        // Restrict to 1 line
+        $iEnd  = strpos($sText, "\n");
+        $sText = ($iEnd === false) ? $sText : substr($sText, 0, $iEnd);
+        if (empty($sText)) {
+            return $this;
+        }
+        $this->writeRightClippedSpan($sText, $iX, $iY, $iMaxX);
+        return $this;
+    }
+
+    /**
+     * Writes a right clipped span of text. Assumes $iY is in range.
+     *
+     * @param string $sText
+     * @param int    $iX
+     * @param int    $iY
+     * @param int    $iMaxX
+     */
+    private function writeRightClippedSpan(string $sText, int $iX, int $iY, $iMaxX) {
+
+        // Handle negative X by chopping off the left
+        if ($iX < 0) {
+            $sText = substr($sText, -$iX);
+            $iX    = 0;
+        }
+        if (empty($sText)) {
+            return $this;
+        }
+
+        $iLength = strlen($sText);
+        if ($iX + $iLength > $iMaxX) {
+            $iLength = $iMaxX - $iX;
+        }
+
+        $iDstIndex = $iY * $this->getCharacterWidth() + $iX;
+        $iSrcIndex = 0;
+        while ($iLength--) {
+            $this->sRawBuffer[$iDstIndex++] = $sText[$iSrcIndex++];
+        }
+
+    }
 }

--- a/src/display/common/TASCIIArt.php
+++ b/src/display/common/TASCIIArt.php
@@ -28,8 +28,9 @@ use ABadCafe\PDE;
  */
 trait TASCIIArt {
 
-    private int
-        $iMaxLuma  = IASCIIArt::DEF_MAX_LUMA,
+    private int $iMaxLuma  = IASCIIArt::DEF_MAX_LUMA;
+
+    protected int
         $iFGColour = IASCIIArt::DEF_FG_COLOUR,
         $iBGColour = IASCIIArt::DEF_BG_COLOUR
     ;

--- a/src/display/common/TAsynchronous.php
+++ b/src/display/common/TAsynchronous.php
@@ -37,7 +37,7 @@ trait TAsynchronous {
     /**
      * @implements IDisplay::waitForFrame()
      */
-    public function waitForFrame() : self {
+    public function waitForFrame() : PDE\IDisplay {
         //return $this;
         $this->sendRawMessage(IAsynchronous::MESSAGE_WAIT_FOR_FRAME);
 

--- a/src/display/common/TPixelled.php
+++ b/src/display/common/TPixelled.php
@@ -36,10 +36,10 @@ trait TPixelled {
     /**
      * @inheritDoc
      */
-    private function initPixelBuffer(int $iWidth, int $iHeight, int $iFormat) {
-        $this->oPixels      = clone // drop through
-        $this->oNewPixels   = SPLFixedArray::fromArray(array_fill(0, $iWidth * $iHeight, 0));
-        $this->iFormat = $iFormat;
+    private function initPixelBuffer(int $iWidth, int $iHeight, int $iFormat, int $iFill) {
+        $this->oPixels    = clone // drop through
+        $this->oNewPixels = SPLFixedArray::fromArray(array_fill(0, $iWidth * $iHeight, $iFill));
+        $this->iFormat    = $iFormat;
     }
 
 
@@ -77,5 +77,11 @@ trait TPixelled {
      */
     public function getRGBWriteMask() : int {
         return $this->iRGBWriteMask;
+    }
+
+    protected function setDefaultPixelValue(int $iValue) {
+        $iCount           = $this->oPixels->count();
+        $this->oPixels    = clone // drop through
+        $this->oNewPixels = SPLFixedArray::fromArray(array_fill(0, $iCount, $iValue));
     }
 }

--- a/src/routine/2D/RGBPersistence.php
+++ b/src/routine/2D/RGBPersistence.php
@@ -68,31 +68,39 @@ class RGBPersistence extends Base {
         $oPixels = $this->oDisplay->getPixels();
         $oLast   = $this->oLastBuffer;
 
+        $iHalfMask =  0x7F7F7F;
+        $iQrtrMask =  0x3F3F3F;
+
+        if ($this->oDisplay->getFormat() & PDE\Graphics\IDrawMode::FG_RGB) {
+            $iHalfMask |= $iHalfMask << 24;
+            $iQrtrMask |= $iQrtrMask << 24;
+        }
+
         // Dosage!
         switch ($this->oParameters->iStrength) {
             case 2:
                 // 75% previous / 25% current
                 foreach ($oLast as $i => $iRGB) {
-                    $iHalfRGB    = ($iRGB >> 1)        & 0x7F7F7F;
-                    $iQrtrRGB    = ($iHalfRGB >> 1)    & 0x3F3F3F;
-                    $iLastRGB    = ($oPixels[$i] >> 2) & 0x3F3F3F;
+                    $iHalfRGB    = ($iRGB >> 1)        & $iHalfMask;
+                    $iQrtrRGB    = ($iHalfRGB >> 1)    & $iQrtrMask;
+                    $iLastRGB    = ($oPixels[$i] >> 2) & $iQrtrMask;
                     $oLast[$i]   = $oPixels[$i] = $iHalfRGB + $iQrtrRGB + $iLastRGB;
                 }
                 break;
             case 1:
                 // 50% previous / 50% current
                 foreach ($oPixels as $i => $iRGB) {
-                    $iHalfRGB    = ($iRGB >> 1)      & 0x7F7F7F;
-                    $iLastRGB    = ($oLast[$i] >> 1) & 0x7F7F7F;
+                    $iHalfRGB    = ($iRGB >> 1)      & $iHalfMask;
+                    $iLastRGB    = ($oLast[$i] >> 1) & $iHalfMask;
                     $oLast[$i]   = $oPixels[$i] = $iHalfRGB + $iLastRGB;
                 }
                 break;
             default:
                 // 25% previous / 75% current
                 foreach ($oPixels as $i => $iRGB) {
-                    $iHalfRGB    = ($iRGB >> 1)      & 0x7F7F7F;
-                    $iQrtrRGB    = ($iHalfRGB >> 1)  & 0x3F3F3F;
-                    $iLastRGB    = ($oLast[$i] >> 2) & 0x3F3F3F;
+                    $iHalfRGB    = ($iRGB >> 1)      & $iHalfMask;
+                    $iQrtrRGB    = ($iHalfRGB >> 1)  & $iQrtrMask;
+                    $iLastRGB    = ($oLast[$i] >> 2) & $iQrtrMask;
                     $oLast[$i]   = $oPixels[$i] = $iHalfRGB + $iQrtrRGB + $iLastRGB;
                 }
                 break;

--- a/src/routine/2D/RGBPulse.php
+++ b/src/routine/2D/RGBPulse.php
@@ -62,7 +62,8 @@ class RGBPulse extends Base {
                 $iRGB = (($y * $fTScale1) & 0xFF) << 8;
                 $iRGB |= (($x * $fTScale2) & 0xFF) << 16;
                 $iRGB |= (($iWidth - $x) * $fTScale3) & 0xFF;
-                $oPixels[$i++] = $iRGB;
+                $oPixels[$i] = ($oPixels[$i] & 0xFFFFFF000000) | $iRGB;
+                ++$i;
             }
         }
         return $this;

--- a/src/routine/2D/TapeLoader.php
+++ b/src/routine/2D/TapeLoader.php
@@ -36,7 +36,7 @@ class TapeLoader extends Base {
         'iHBorder'  => 5,
         'iVBorder'  => 10,
         'sMessage'  => "",
-        'iMessageX' => 0,
+        'iMessageX' => 2,
         'iMessageY' => 4
     ];
 
@@ -53,7 +53,7 @@ class TapeLoader extends Base {
         $iSyncRGB2  = 0x0022D7D7,
         $iLoadRGB1  = 0x002222D7,
         $iLoadRGB2  = 0x00D7D722,
-        $iLastRGB   = 0
+        $iLastRGB   = 0xFF000000
     ;
 
     private float $fLastIdle  = 0.0;
@@ -64,10 +64,10 @@ class TapeLoader extends Base {
      * @inheritDoc
      */
     public function setDisplay(PDE\IDisplay $oDisplay) : self {
-        $this->bCanRender   =
+        $this->bCanRender =
             ($oDisplay instanceof PDE\Display\IPixelled) &&
             (($oDisplay->getFormat() & self::NEED_FORMAT) == self::NEED_FORMAT);
-        $this->oDisplay     = $oDisplay;
+        $this->oDisplay = $oDisplay;
         return $this;
     }
 

--- a/src/system/Context.php
+++ b/src/system/Context.php
@@ -85,6 +85,7 @@ class Context {
             $this->oDisplay->clear();
             $this->runRoutines($iFrameNumber, $fTimeIndex);
             $this->oDisplay->redraw();
+
             $fTimeIndex = $this->oRateLimiter->limit();
             $iFrameNumber++;
         }

--- a/src/tests/text_test.php
+++ b/src/tests/text_test.php
@@ -1,0 +1,40 @@
+<?php
+
+
+declare(strict_types = 1);
+
+namespace ABadCafe\PDE;
+
+require_once '../PDE.php';
+
+$iWidth  = 120;
+$iHeight = 30;
+
+
+$oDisplay = Display\Factory::get()->create('PlainASCII', $iWidth, $iHeight);
+$oDisplay
+    ->reset()
+    ->setBackgroundColour(4)
+    ->writeTextSpan("Top Left", 0, 0)
+    ->writeTextSpan("Top Right", 111, 0)
+    ->writeTextSpan("Bottom Left", 0, 29)
+    ->writeTextSpan("Bottom Right", 108, 29)
+    ->writeTextSpan("Centre", 57, 15)
+    ->writeTextSpan(str_repeat("0123456789", 20), 0, 2)
+    ->writeTextSpan("Off Left", -20, 15)
+    ->writeTextSpan("Off Right", 120, 15)
+    ->writeTextSpan("Off Top", 0, -1)
+    ->writeTextSpan("Off Bottom", 0, 30)
+    ->writeTextSpan("Hidden Clip Left", -7, 15)
+    ->writeTextSpan("Clip Right Hidden", 120 - 10, 15)
+    ->writeTextSpan("Visible Line\nHidden Line", 54, 0)
+    ->redraw();
+
+sleep(5);
+
+
+$oDisplay
+    ->reset()
+    ->writeTextBounded(file_get_contents('text_test.php'), 0, 0)
+    ->redraw()
+    ->waitForFrame();


### PR DESCRIPTION
Added the ability to render text spans and blocks on IASCIIArt displays directly without manually having to mash it.
- Handles negative offsets, clipping, etc.
Fixed a number of annoying bugs around foreground and background default colours.
- Setting these for an IPixelled display will fill the pixel buffer accordingly.
- Fixed issues caused by routines with no awareness that foreground colour is a thing (e.g. rgb persistence, pulse etc)
Fixed some more PHP7.4 only covariance issues when mixing interfaces, traits and base classes.
- Sigh